### PR TITLE
FIX: Allow non-admin users to access CMS user guide

### DIFF
--- a/src/Admin/UserGuideAdmin.php
+++ b/src/Admin/UserGuideAdmin.php
@@ -13,6 +13,8 @@ class UserGuideAdmin extends LeftAndMain
 
     private static $menu_priority = -1;
 
+    private static $required_permission_codes = 'CMS_ACCESS_CMSMain';
+
     /**
      * The embed code for the user guide
      *


### PR DESCRIPTION
Currently only admins can access the user guide, so expanding that permission to include all uses who can access the CMS